### PR TITLE
Restyle docs hub with coverage map

### DIFF
--- a/src/website/docs.css
+++ b/src/website/docs.css
@@ -46,3 +46,100 @@
         }
     }
 }
+
+.guide-section > main {
+    max-width: 1200px;
+    margin: 0 auto 3em;
+    padding: 0 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+    font-family: 'Inter', sans-serif;
+}
+
+.guide-intro {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    line-height: 1.6;
+    color: #1f2a44;
+}
+
+.doc-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.25rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.doc-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1.25rem 1.5rem;
+    background: #ffffff;
+    border-radius: 14px;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.05);
+    text-decoration: none;
+    color: #111827;
+    transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+}
+
+.doc-card:hover,
+.doc-card:focus {
+    transform: translateY(-3px);
+    border-color: rgba(226, 137, 3, 0.45);
+    box-shadow: 0 10px 24px rgba(226, 137, 3, 0.14);
+}
+
+.doc-card-title {
+    font-size: 1.1em;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.doc-card-body {
+    font-size: 0.98em;
+    line-height: 1.5;
+    color: #374151;
+}
+
+.guide-group {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.guide-group h2 {
+    margin: 0;
+    font-size: 1.5em;
+    color: #0f172a;
+}
+
+.coverage-map {
+    background: #f8fafc;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    border-radius: 14px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.04);
+}
+
+.coverage-map h3 {
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    color: #111827;
+}
+
+.coverage-map ul {
+    padding-left: 1.2rem;
+    line-height: 1.5;
+    margin-top: 0.25rem;
+    margin-bottom: 1rem;
+}
+
+.coverage-map li + li {
+    margin-top: 0.35rem;
+}

--- a/src/website/docs/folded-paper-engine-guide.html
+++ b/src/website/docs/folded-paper-engine-guide.html
@@ -41,7 +41,7 @@
         </div>
     </section>
     <section
-            class="section top-section"
+            class="section top-section guide-section"
     >
         <header>
             <div
@@ -54,72 +54,137 @@
             </div>
         </header>
         <main>
-            <p>
-                The Folded Paper Engine documentation lives across focused reference pages so you can jump directly to
-                the system you need. Everything here mirrors the actual Blender exporter and Godot runtime code so that
-                the behavior you see in-game matches what is described.
-            </p>
-            <p>
-                Start with installation, then explore pipeline, scene configuration, runtime features, and troubleshooting
-                topics using the links below.
-            </p>
-            <div class="doc-grid">
-                <a class="doc-card" href="./fpe-installation.html">
-                    <div class="doc-card-title">Installation</div>
-                    <div class="doc-card-body">Blender add-on, Godot plug-in, and project setup.</div>
-                </a>
-                <a class="doc-card" href="./fpe-pipeline.html">
-                    <div class="doc-card-title">Pipeline and Runtime</div>
-                    <div class="doc-card-body">GLB import flow, load/unload lifecycle, and feature registration.</div>
-                </a>
-                <a class="doc-card" href="./fpe-scene-settings.html">
-                    <div class="doc-card-title">Scene Settings</div>
-                    <div class="doc-card-body">Sky color, gravity overrides, music, and scene-level events.</div>
-                </a>
-                <a class="doc-card" href="./fpe-object-behaviors.html">
-                    <div class="doc-card-title">Objects and Characters</div>
-                    <div class="doc-card-body">Player rigs, characters, physics bodies, speakers, cameras.</div>
-                </a>
-                <a class="doc-card" href="./fpe-physics-and-colliders.html">
-                    <div class="doc-card-title">Physics and Colliders</div>
-                    <div class="doc-card-body">Rigid bodies, collider generation, holdable bodies, and movement.</div>
-                </a>
-                <a class="doc-card" href="./fpe-animation-and-events.html">
-                    <div class="doc-card-title">Animation and Frame Events</div>
-                    <div class="doc-card-body">Animation imports, frame-timed events, and playback control.</div>
-                </a>
-                <a class="doc-card" href="./fpe-audio.html">
-                    <div class="doc-card-title">Audio</div>
-                    <div class="doc-card-body">Speakers, autoplay, looping, and background music playlists.</div>
-                </a>
-                <a class="doc-card" href="./fpe-triggers-commands.html">
-                    <div class="doc-card-title">Triggers and Commands</div>
-                    <div class="doc-card-body">Areas, trigger filters, command catalog, and automation.</div>
-                </a>
-                <a class="doc-card" href="./fpe-inventory-and-holdables.html">
-                    <div class="doc-card-title">Inventory and Holdables</div>
-                    <div class="doc-card-body">Item kinds, slots, pickup zones, deposits, and player UI hooks.</div>
-                </a>
-                <a class="doc-card" href="./fpe-conversations-and-ui.html">
-                    <div class="doc-card-title">Conversations and UI</div>
-                    <div class="doc-card-body">Dialogue data, UI options, cursors, and on-screen interactions.</div>
-                </a>
-                <a class="doc-card" href="./fpe-input-and-cameras.html">
-                    <div class="doc-card-title">Input and Cameras</div>
-                    <div class="doc-card-body">Action maps, controllers, camera activation, and player toggles.</div>
-                </a>
-                <a class="doc-card" href="./fpe-subscenes-and-levels.html">
-                    <div class="doc-card-title">Sub Scenes and Level Loading</div>
-                    <div class="doc-card-body">Level streaming, pausing, and load/unload triggers.</div>
-                </a>
-                <a class="doc-card" href="./fpe-troubleshooting.html">
-                    <div class="doc-card-title">Troubleshooting</div>
-                    <div class="doc-card-body">Common pipeline pitfalls and quick validation checks.</div>
-                </a>
-                <a class="doc-card" href="./fpe-doc-coverage.html">
-                    <div class="doc-card-title">Coverage Map</div>
-                    <div class="doc-card-body">See where every feature is documented and close any gaps fast.</div>
-                </a>
+            <div class="guide-intro">
+                <p>
+                    Everything here mirrors the Blender exporter and Godot runtime so the behavior you see in-game matches
+                    what is described. Start with installation, then move into scene setup and the gameplay systems you want
+                    to use.
+                </p>
+                <p>
+                    Cards below are grouped by creator workflow. Each one links to a friendly, step-by-step page for minimally
+                    technical users.
+                </p>
+            </div>
+
+            <div class="guide-group">
+                <h2>Start here</h2>
+                <div class="doc-grid">
+                    <a class="doc-card" href="./fpe-installation.html">
+                        <div class="doc-card-title">Installation</div>
+                        <div class="doc-card-body">Blender add-on, Godot plug-in, and project setup.</div>
+                    </a>
+                    <a class="doc-card" href="./fpe-pipeline.html">
+                        <div class="doc-card-title">Pipeline and Runtime</div>
+                        <div class="doc-card-body">GLB export settings, importer flow, and how the runtime wires features.</div>
+                    </a>
+                    <a class="doc-card" href="./fpe-troubleshooting.html">
+                        <div class="doc-card-title">Troubleshooting</div>
+                        <div class="doc-card-body">Quick validation checks for exports, plugins, scaling, and refreshes.</div>
+                    </a>
+                </div>
+            </div>
+
+            <div class="guide-group">
+                <h2>Core scene setup</h2>
+                <div class="doc-grid">
+                    <a class="doc-card" href="./fpe-scene-settings.html">
+                        <div class="doc-card-title">Scene Settings</div>
+                        <div class="doc-card-body">Sky color, gravity overrides, background music, and scene-level events.</div>
+                    </a>
+                    <a class="doc-card" href="./fpe-object-behaviors.html">
+                        <div class="doc-card-title">Objects and Characters</div>
+                        <div class="doc-card-body">Player rigs, characters, physics bodies, speakers, and cameras.</div>
+                    </a>
+                    <a class="doc-card" href="./fpe-physics-and-colliders.html">
+                        <div class="doc-card-title">Physics and Colliders</div>
+                        <div class="doc-card-body">Rigid bodies, collider generation, holdable bodies, and movement helpers.</div>
+                    </a>
+                </div>
+            </div>
+
+            <div class="guide-group">
+                <h2>Gameplay systems</h2>
+                <div class="doc-grid">
+                    <a class="doc-card" href="./fpe-animation-and-events.html">
+                        <div class="doc-card-title">Animation and Frame Events</div>
+                        <div class="doc-card-body">Animation imports, frame-timed events, and playback control.</div>
+                    </a>
+                    <a class="doc-card" href="./fpe-audio.html">
+                        <div class="doc-card-title">Audio</div>
+                        <div class="doc-card-body">Speakers, autoplay, looping, background music playlists, and fixes.</div>
+                    </a>
+                    <a class="doc-card" href="./fpe-triggers-commands.html">
+                        <div class="doc-card-title">Triggers and Commands</div>
+                        <div class="doc-card-body">Trigger setup, filters, command catalog, and automation recipes.</div>
+                    </a>
+                    <a class="doc-card" href="./fpe-inventory-and-holdables.html">
+                        <div class="doc-card-title">Inventory and Holdables</div>
+                        <div class="doc-card-body">Item kinds, slots, pickup zones, deposits, and player UI hooks.</div>
+                    </a>
+                    <a class="doc-card" href="./fpe-conversations-and-ui.html">
+                        <div class="doc-card-title">Conversations and UI</div>
+                        <div class="doc-card-body">Dialogue data, UI options, cursors, and on-screen interactions.</div>
+                    </a>
+                    <a class="doc-card" href="./fpe-input-and-cameras.html">
+                        <div class="doc-card-title">Input and Cameras</div>
+                        <div class="doc-card-body">Action maps, controllers, camera activation, and player toggles.</div>
+                    </a>
+                </div>
+            </div>
+
+            <div class="guide-group">
+                <h2>Levels and streaming</h2>
+                <div class="doc-grid">
+                    <a class="doc-card" href="./fpe-subscenes-and-levels.html">
+                        <div class="doc-card-title">Sub Scenes and Level Loading</div>
+                        <div class="doc-card-body">Level streaming, portals, pausing parents, and load/unload triggers.</div>
+                    </a>
+                </div>
+            </div>
+
+            <div id="coverage-map" class="guide-group">
+                <h2>Coverage map</h2>
+                <div class="coverage-map">
+                    <p>
+                        Double-check where every feature from our blind-spot review is covered. Use this as a table of contents
+                        and sanity check before sharing docs with new creators.
+                    </p>
+
+                    <h3>Gameplay and interactions</h3>
+                    <ul>
+                        <li><strong>Players and Characters:</strong> See <a href="./fpe-object-behaviors.html">Objects and Characters</a> for tagging players/NPCs, physics bodies, and cameras.</li>
+                        <li><strong>Holdables and Inventory:</strong> <a href="./fpe-inventory-and-holdables.html">Inventory and Holdables</a> walks through item kinds, slots, pickup/drop, and UI hooks.</li>
+                        <li><strong>Triggers and Commands:</strong> <a href="./fpe-triggers-commands.html">Triggers and Commands</a> includes step-by-step trigger setup, command chaining, and puzzle patterns.</li>
+                        <li><strong>Dialogues and UI:</strong> <a href="./fpe-conversations-and-ui.html">Conversations and UI</a> covers crosshair, cursor unlock, dialogue authoring, and prompts.</li>
+                    </ul>
+
+                    <h3>Timing, audio, and feedback</h3>
+                    <ul>
+                        <li><strong>Frame Events:</strong> <a href="./fpe-animation-and-events.html">Animation and Frame Events</a> shows how to mark frames in Blender and hook them to sounds, doors, or cameras.</li>
+                        <li><strong>Audio and Music:</strong> <a href="./fpe-audio.html">Audio</a> explains Speakers, background music, distance falloff, looping, and troubleshooting.</li>
+                    </ul>
+
+                    <h3>Levels, loading, and scene settings</h3>
+                    <ul>
+                        <li><strong>Whole-level transitions:</strong> <a href="./fpe-subscenes-and-levels.html">Sub Scenes and Level Loading</a> has door recipes, portal hubs, and unload safety notes.</li>
+                        <li><strong>Sub-scenes/streaming:</strong> Same guide shows how to nest interiors and pause parents while loaded.</li>
+                        <li><strong>Environment metadata:</strong> <a href="./fpe-scene-settings.html">Scene Settings</a> covers sky color, gravity overrides, background music defaults, and FX toggles.</li>
+                    </ul>
+
+                    <h3>Pipeline and troubleshooting</h3>
+                    <ul>
+                        <li><strong>Install and export:</strong> <a href="./fpe-installation.html">Installation</a> and <a href="./fpe-pipeline.html">Pipeline and Runtime</a> explain the Blender ↔ Godot loop, importer behaviors, and how to refresh exports safely.</li>
+                        <li><strong>Common pitfalls:</strong> <a href="./fpe-troubleshooting.html">Troubleshooting</a> lists quick checks for scale, transforms, missing plugins, and stale imports.</li>
+                    </ul>
+
+                    <h3>Advanced extensions</h3>
+                    <ul>
+                        <li><strong>Custom scripts and groups:</strong> <a href="./fpe-object-behaviors.html">Objects and Characters</a> highlights ScriptPath and groups so advanced users can extend without breaking the pipeline.</li>
+                        <li><strong>Visual overrides:</strong> Material and reflective tweaks are documented under <a href="./fpe-physics-and-colliders.html">Physics and Colliders</a> and <a href="./fpe-object-behaviors.html">Objects and Characters</a> for easy lookup.</li>
+                    </ul>
+
+                    <p>If you spot a feature that is not linked here, add a friendly section to the relevant page and update this map so creators always know where to look.</p>
+                </div>
             </div>
         </main>
     </section>


### PR DESCRIPTION
## Summary
- redesigned the documentation hub with card-based groups for clearer navigation
- embedded the coverage map directly on the hub page and refreshed copy for creator-friendly guidance
- added supportive CSS for the new grid, card, and coverage sections to improve readability

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923842108488323a2d329361d9b6c5a)