### PR TITLE
Add merged guidance callouts to documentation pages

### DIFF
--- a/src/website/docs/folded-paper-engine-guide.html
+++ b/src/website/docs/folded-paper-engine-guide.html
@@ -73,6 +73,17 @@
                             <li><a href="./fpe-pipeline.html#checking-imports">Check importer output</a> and <a href="./fpe-pipeline.html#registering-features">register features</a> before adding gameplay.</li>
                             <li><a href="./fpe-triggers-commands.html#common-recipes">Use trigger recipes</a> to hand items, play audio, and drive level changes.</li>
                             <li><a href="./fpe-doc-coverage.html">Coverage map</a> shows where every system is documented so you can jump straight to details.</li>
+                            <li><a href="./fpe-troubleshooting.html#log-checks">Troubleshooting log checks</a> help you verify importer, renderer, and runtime state without guessing.</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="callout">
+                    <div class="callout-title">Documentation navigation tips</div>
+                    <div class="callout-body">
+                        <ul>
+                            <li>Use the coverage map when you need to confirm whether a feature is documented or still in flight.</li>
+                            <li>Jump between related systems using the "See also" sections inside each page to follow the authoring workflow.</li>
+                            <li>Bookmark this hub—the card grid below mirrors the Blender and Godot terminology so you can reach the right guide fast.</li>
                         </ul>
                     </div>
                 </div>

--- a/src/website/docs/fpe-installation.html
+++ b/src/website/docs/fpe-installation.html
@@ -25,15 +25,28 @@
         <img class="dl-icon" src="../dl-icon.png" alt="Download">
     </a>
 </header>
-<main>
-    <section class="section top-section">
-        <header>
-            <div class="section-title">
-                Installation and Project Setup
-                <div class="section-subtitle">Blender exporter + Godot runtime</div>
-            </div>
-        </header>
+    <main>
+        <section class="section top-section">
+            <header>
+                <div class="section-title">
+                    Installation and Project Setup
+                    <div class="section-subtitle">Blender exporter + Godot runtime</div>
+                </div>
+            </header>
         <main>
+            <div class="callouts">
+                <div class="callout">
+                    <div class="callout-title">Preflight checklist</div>
+                    <div class="callout-body">
+                        <ul>
+                            <li>Install the Godot plug-in and enable it under <strong>Project Settings → Plugins</strong>.</li>
+                            <li>Enable the Blender exporter and confirm the <strong>Folded Paper Engine</strong> panel appears in the <strong>N</strong> sidebar.</li>
+                            <li>Open the sample project once so the importer generates <code>.import</code> assets for faster reimports.</li>
+                            <li>Run <a href="./fpe-pipeline.html#checking-imports">importer log checks</a> before wiring up gameplay to ensure asset and metadata paths resolve.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
             <h2>Blender add-on</h2>
             <ol>
                 <li>Open <strong>Edit → Preferences → Add-ons</strong> in Blender.</li>

--- a/src/website/docs/fpe-inventory-and-holdables.html
+++ b/src/website/docs/fpe-inventory-and-holdables.html
@@ -34,6 +34,18 @@
             </div>
         </header>
         <main>
+            <div class="callouts">
+                <div class="callout">
+                    <div class="callout-title">Setup recap</div>
+                    <div class="callout-body">
+                        <ul>
+                            <li>Author items in Blender with clear root object names so the importer can register holdable transforms.</li>
+                            <li>Define <strong>Inventory Item Kind</strong> and <strong>Quantity</strong> metadata to keep stacks consistent across levels.</li>
+                            <li>Use <a href="./fpe-triggers-commands.html#common-recipes">trigger recipes</a> to hand items to the player and to deposit holdables into inventory slots.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
             <h2>Inventory (stored items)</h2>
             <ol>
                 <li>Create the item in Blender, then under <strong>Folded Paper Engine → Inventory Item</strong> set the <strong>Inventory Item Kind</strong> ID and a starting <strong>Quantity</strong>.</li>

--- a/src/website/docs/fpe-subscenes-and-levels.html
+++ b/src/website/docs/fpe-subscenes-and-levels.html
@@ -34,6 +34,18 @@
             </div>
         </header>
         <main>
+            <div class="callouts">
+                <div class="callout">
+                    <div class="callout-title">Scene loading essentials</div>
+                    <div class="callout-body">
+                        <ul>
+                            <li>Keep a root <strong>Folded Paper Engine</strong> node active and load sub-scenes under it so feature registration stays stable.</li>
+                            <li>Pair level changes with <a href="./fpe-triggers-commands.html#command-catalog">commands</a> that fade audio, detach holdables, and clean up triggers before unloading.</li>
+                            <li>Use a lightweight loading or fade sub-scene to mask transitions so players never see streaming artifacts.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
             <h2>One-click whole level transitions</h2>
             <ol>
                 <li>Place a trigger near your doorway or portal (see Triggers guide).</li>

--- a/src/website/docs/fpe-troubleshooting.html
+++ b/src/website/docs/fpe-troubleshooting.html
@@ -34,6 +34,18 @@
             </div>
         </header>
         <main>
+            <div class="callouts">
+                <div class="callout">
+                    <div class="callout-title">Log checks</div>
+                    <div class="callout-body">
+                        <ul>
+                            <li>Confirm the importer found <code>custom_properties.json</code> for your GLB and registered inventory, triggers, and cameras.</li>
+                            <li>If you see missing resource warnings, re-export from Blender and delete the GLB’s <code>.import</code> folder before reopening the project.</li>
+                            <li>After enabling the plug-in or switching branches, restart Godot so input actions and runtime singletons rebind cleanly.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
             <h2>GLB import issues</h2>
             <ul>
                 <li><strong>Correct export settings:</strong> in Blender’s GLTF export dialog check <strong>Custom Properties</strong>, <strong>Cameras</strong>, <strong>Punctual Lights</strong>, and <strong>Remember Export Settings</strong> before saving to your Godot project folder.</li>


### PR DESCRIPTION
## Summary
- add navigation and troubleshooting callouts to the documentation hub
- add preflight and logging checklists across installation, inventory, sub-scene, and troubleshooting guides

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923a6b7777083239b10cc398a97f83a)