### PR TITLE
Normalize docs layout structure

### DIFF
--- a/src/website/docs.css
+++ b/src/website/docs.css
@@ -1,71 +1,69 @@
-.section {
-    &.content-section {
-        background-color: #fff;
-        color: black;
-        text-shadow: none;
-    }
-
-    > main {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        justify-content: flex-start;
-        gap: 1em;
-        font-family: sans-serif;
-        word-break: break-word;
-        margin-bottom: 4em;
-        font-size: 1.25em;
-
-        > h3 {
-            font-family: 'ZCOOLKuaiLe-Regular', sans-serif;
-        }
-
-        a {
-            color: #e28903;
-            text-decoration: none;
-        }
-
-        .property-group {
-            color: #555555;
-        }
-
-        .doc-columns {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-            gap: 1.5em;
-            width: 100%;
-        }
-
-        .doc-column {
-            background: #f7f7f7;
-            border-radius: 12px;
-            padding: 1.25em 1.5em;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-            display: flex;
-            flex-direction: column;
-            gap: 0.5em;
-        }
-
-        .doc-column h3 {
-            margin: 0;
-            font-family: 'ZCOOLKuaiLe-Regular', sans-serif;
-        }
-
-        .doc-column ul {
-            margin: 0;
-            padding-left: 1em;
-            display: flex;
-            flex-direction: column;
-            gap: 0.35em;
-        }
-
-        .doc-column li {
-            line-height: 1.4;
-        }
-    }
+.section.content-section {
+    background-color: #fff;
+    color: black;
+    text-shadow: none;
 }
 
-.guide-section > main {
+.section > .section-body {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 1em;
+    font-family: sans-serif;
+    word-break: break-word;
+    margin-bottom: 4em;
+    font-size: 1.25em;
+}
+
+.section > .section-body > h3 {
+    font-family: 'ZCOOLKuaiLe-Regular', sans-serif;
+}
+
+.section > .section-body a {
+    color: #e28903;
+    text-decoration: none;
+}
+
+.section > .section-body .property-group {
+    color: #555555;
+}
+
+.section > .section-body .doc-columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.5em;
+    width: 100%;
+}
+
+.section > .section-body .doc-column {
+    background: #f7f7f7;
+    border-radius: 12px;
+    padding: 1.25em 1.5em;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+}
+
+.section > .section-body .doc-column h3 {
+    margin: 0;
+    font-family: 'ZCOOLKuaiLe-Regular', sans-serif;
+}
+
+.section > .section-body .doc-column ul {
+    margin: 0;
+    padding-left: 1em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35em;
+}
+
+.section > .section-body .doc-column li {
+    line-height: 1.4;
+}
+
+.guide-section > .section-body {
     max-width: 1200px;
     margin: 0 auto 3em;
     padding: 0 1.5rem;

--- a/src/website/docs/folded-paper-engine-guide.html
+++ b/src/website/docs/folded-paper-engine-guide.html
@@ -53,7 +53,7 @@
                 </div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <p>
                 The Folded Paper Engine documentation lives across focused reference pages so you can jump directly to
                 the system you need. Everything here mirrors the actual Blender exporter and Godot runtime code so that
@@ -174,7 +174,7 @@
                     <div class="doc-card-body">See where every feature is documented and close any gaps fast.</div>
                 </a>
             </div>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-animation-and-events.html
+++ b/src/website/docs/fpe-animation-and-events.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Beginner-friendly timing for cutscenes, doors, and VFX</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>How animation import works</h2>
             <ul>
                 <li>Every Action you key in Blender keeps its name when exported. FPE registers mesh animations and sprite animations in a global map when the GLB loads so commands can find them later.</li>
@@ -70,7 +70,7 @@
                 <li>Make sure the GLB was re-exported after adding events and that Godot re-imported it.</li>
                 <li>If your event happens between frames, slow playback slightly or move the marker to an exact frame number.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-audio.html
+++ b/src/website/docs/fpe-audio.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Speakers, looping, autoplay, and background music</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>Quick setup: one object that plays a sound</h2>
             <ol>
                 <li>Select the mesh or empty that should make noise (for example, a flickering light, a buzzing fan, or an NPC).</li>
@@ -70,7 +70,7 @@
                 <li>Volume too loud or quiet? Nudge <strong>SpeakerVolume</strong> up or down a few dB, then re-export the GLB.</li>
                 <li>Need the sound only indoors or in a small area? Lower <strong>SpeakerMaxDistance</strong> so it fades out quickly.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-cameras.html
+++ b/src/website/docs/fpe-cameras.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Player camera settings, swaps, and best practices</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>Player camera basics</h2>
             <ol>
                 <li>Select your Player object in Blender and open <strong>Player Controls</strong>.</li>
@@ -52,7 +52,7 @@
                 <li>Apply transforms in Blender before export to avoid offset cameras in Godot.</li>
                 <li>Test sensitivity and field of view early; small adjustments can make the controls feel polished for Creator Users.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-conversations.html
+++ b/src/website/docs/fpe-conversations.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Speaker setup, dialogue data, and progression</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>Create a conversation-ready character</h2>
             <ol>
                 <li>Select the character mesh or rig in Blender and open the <strong>Folded Paper Engine</strong> panel.</li>
@@ -58,7 +58,7 @@
                 <li>Test with multiple characters present; required characters must be in the scene so the dialogue has valid speakers.</li>
                 <li>Pair conversations with animation or audio by firing an Event Command or Frame Event when a key line is reached.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-doc-coverage.html
+++ b/src/website/docs/fpe-doc-coverage.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Where to learn every feature, tailored for minimally technical creators</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <p>This page double-checks that every Folded Paper Engine feature called out in our blind-spot review is covered by a friendly guide. Use it as a table of contents and a sanity check before sharing docs with new creators.</p>
 
             <h2>Gameplay and interactions</h2>
@@ -71,7 +71,7 @@
             </ul>
 
             <p>If you spot a feature that is not linked here, add a friendly section to the relevant page and update this map so creators always know where to look.</p>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-input.html
+++ b/src/website/docs/fpe-input.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Action maps, controller support, and player-friendly prompts</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>Default actions</h2>
             <ul>
                 <li>FPE ships with sensible defaults for Move, Look, Jump, Use, Inventory, and Toggle Menu. Map them in Godot’s Input Map before running.</li>
@@ -50,7 +50,7 @@
                 <li>Bind a Pause or Options action to unlock the cursor and show your menus. Returning to the game locks the pointer and re-enables look input.</li>
                 <li>Keep menu navigation simple: Up/Down/Confirm/Back should mirror keyboard, mouse, and controller inputs.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-installation.html
+++ b/src/website/docs/fpe-installation.html
@@ -33,7 +33,7 @@
                     <div class="section-subtitle">Blender exporter + Godot runtime</div>
                 </div>
             </header>
-        <main>
+        <div class="section-body">
             <div class="callouts">
                 <div class="callout">
                     <div class="callout-title">Preflight checklist</div>
@@ -93,7 +93,7 @@
                 <li>Verify the plug-in is active any time you clone the repo or switch machines; FPE nodes rely on the runtime scripts being enabled.</li>
                 <li>Set a <strong>.gitattributes</strong> rule for binary GLB files if you use Git LFS so large exports don’t break your history.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-inventory-and-holdables.html
+++ b/src/website/docs/fpe-inventory-and-holdables.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Item kinds, slots, hold zones, and deposits</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <div class="callouts">
                 <div class="callout">
                     <div class="callout-title">Setup recap</div>
@@ -78,7 +78,7 @@
                     </div>
                 </div>
             </div>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-object-behaviors.html
+++ b/src/website/docs/fpe-object-behaviors.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Player rigs, NPCs, cameras, and speaker nodes</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>Players vs. Characters</h2>
             <ul>
                 <li><strong>PlayerControls:</strong> wraps <code>CharacterControls</code> with camera setup, device proxies, and hold zones. First-person enables a tight offset camera; third-person aligns and follows.</li>
@@ -56,7 +56,7 @@
                 <li>Use Blender groups or custom ScriptPath metadata to bind Godot scripts to imported nodes without manual scene edits.</li>
                 <li>Groups are respected at import time, enabling command filters and deletion-by-group commands.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-physics-and-colliders.html
+++ b/src/website/docs/fpe-physics-and-colliders.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Rigid bodies, collision generation, and movement flags</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>Rigid bodies</h2>
             <ul>
                 <li>Objects tagged with physics data become <code>RigidBody3D</code> instances. Movement and jump forces are applied in the physics step.</li>
@@ -50,7 +50,7 @@
                 <li>Scene-level gravity overrides affect all rigid bodies. Characters read the global default gravity when applying forces.</li>
                 <li>Player turn speed, mouse sensitivity, and camera pitch clamping are configurable in Blender and applied at runtime.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-pipeline.html
+++ b/src/website/docs/fpe-pipeline.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">GLB import, pointer capture, and feature registration</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>Engine node responsibilities</h2>
             <ul>
                 <li><strong>Pointer capture:</strong> when a <code>FoldedPaperEngine</code> node enters the tree, it remembers the prior
@@ -58,7 +58,7 @@
                 <li>Register load hooks with <code>add_load_proceedure</code> to prepare UI, save data, or spawn systems before a level appears.</li>
                 <li>Register unload hooks for analytics, save checkpoints, or clearing external caches.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-scene-settings.html
+++ b/src/website/docs/fpe-scene-settings.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Environment, gravity, music, and scene events</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>Environment overrides</h2>
             <ul>
                 <li><strong>Sky Color:</strong> Set in Blender on the scene context. During load, the SkyColor effect applies the tint to the shared <code>WorldEnvironment</code> so new levels inherit the same background.</li>
@@ -49,7 +49,7 @@
                 <li>Scene-level event data is kept on the scene root so triggers and animations can assemble participant metadata when dispatching events.</li>
                 <li>Use event names consistently across triggers, frame events, and commands so handlers in the Godot scene tree can listen with <code>FPEEventManager</code>.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-subscenes-and-levels.html
+++ b/src/website/docs/fpe-subscenes-and-levels.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Friendly recipes for doors, hubs, and streamed interiors</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <div class="callouts">
                 <div class="callout">
                     <div class="callout-title">Scene loading essentials</div>
@@ -109,7 +109,7 @@
                 <li>Apply transforms before export so the sub-scene spawns at the expected size and position.</li>
                 <li>If old sounds or cameras keep playing after a load, make sure you are using <strong>LoadLevel</strong> (not a custom script) so the runtime clears registries.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-triggers-commands.html
+++ b/src/website/docs/fpe-triggers-commands.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Step-by-step areas, filters, and the no-code action list</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>Create a trigger zone in Blender</h2>
             <ol>
                 <li>Select or add a simple cube/empty for your trigger. Scale it to cover the area you want to react to (e.g., a doorway).</li>
@@ -83,7 +83,7 @@
                 <li>Check the <strong>Group</strong> filter: wrong group means the engine ignores the overlap.</li>
                 <li>Use simple box triggers unless you truly need mesh-shaped bounds for performance reasons.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-troubleshooting.html
+++ b/src/website/docs/fpe-troubleshooting.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Common pipeline issues and fixes</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <div class="callouts">
                 <div class="callout">
                     <div class="callout-title">Log checks</div>
@@ -67,7 +67,7 @@
                 <li><strong>Paused controls:</strong> if movement is frozen, check the global deactivate flags (player controls, character movement, triggers, UI). Commands may have toggled these during cutscenes.</li>
                 <li><strong>Missing transition fades:</strong> load the fade sub-scene just before running <code>LoadLevel</code>, then unload it in the new scene once the player regains control.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">

--- a/src/website/docs/fpe-ui.html
+++ b/src/website/docs/fpe-ui.html
@@ -33,7 +33,7 @@
                 <div class="section-subtitle">Crosshairs, UI Elements, and menu-friendly mouse modes</div>
             </div>
         </header>
-        <main>
+        <div class="section-body">
             <h2>UI Elements in Blender</h2>
             <ul>
                 <li>Marking an object as a <strong>UI Element</strong> tells FPE that the object can be used as a <strong>UI Option</strong> (menu element) or as a <strong>UI Cursor</strong>.</li>
@@ -52,7 +52,7 @@
                 <li>For diegetic overlays (like a visor or helmet), parent the UI Element to the active camera so it always follows the view.</li>
                 <li>Keep UI colors and stroke weights readable on bright scenes; adding a subtle drop shadow in Blender helps text stand out after import.</li>
             </ul>
-        </main>
+        </div>
     </section>
 </main>
 <footer class="footer">


### PR DESCRIPTION
## Summary
- Replace nested inner `<main>` blocks across documentation pages with `.section-body` containers for valid single-main HTML structure
- Update docs stylesheet to target the new containers with standard CSS selectors while preserving the existing layout and spacing

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b72e16488323b6a1a6b49699fb84)