### PR TITLE
Polish documentation terminology for creator-facing commands

### DIFF
--- a/src/website/docs/fpe-animation-and-events.html
+++ b/src/website/docs/fpe-animation-and-events.html
@@ -60,7 +60,7 @@
             <ul>
                 <li><strong>Play a sound mid-animation:</strong> Add a frame event named <code>play_chime</code>. Place a Trigger or Speaker nearby that listens for the <code>play_chime</code> event and fires a <code>SpeakerTrigger</code> command.</li>
                 <li><strong>Unlock a door on frame 12:</strong> Mark frame 12 as <code>unlock_door</code>. Add a Trigger on the door mesh that reacts to <code>unlock_door</code> by disabling the collider or running <code>Animations</code> to play the open clip.</li>
-                <li><strong>Cutscene camera swap:</strong> Use two frame events, <code>cam_cut</code> and <code>cam_return</code>, and bind them to <code>ActivateCamera</code> and <code>ReactivatePlayerCamera</code> commands to keep control smooth for non-coders.</li>
+                <li><strong>Cutscene camera swap:</strong> Use two frame events, <code>cam_cut</code> and <code>cam_return</code>, and bind them to the <strong>Activate Camera</strong> (<code>ActivateCamera</code>) and <strong>Reactivate Player Camera</strong> (<code>ReactivatePlayerCamera</code>) commands to keep control smooth for non-coders.</li>
             </ul>
 
             <h2>Quick checklist if nothing fires</h2>

--- a/src/website/docs/fpe-doc-coverage.html
+++ b/src/website/docs/fpe-doc-coverage.html
@@ -66,7 +66,7 @@
 
             <h2>Advanced extensions</h2>
             <ul>
-                <li><strong>Custom scripts and groups:</strong> <a href="./fpe-object-behaviors.html">Objects and Characters</a> highlights ScriptPath and groups so advanced users can extend without breaking the pipeline.</li>
+                <li><strong>Custom scripts and groups:</strong> <a href="./fpe-object-behaviors.html">Objects and Characters</a> highlights the <strong>Script Path</strong> option (<code>ScriptPath</code>) and groups so advanced users can extend without breaking the pipeline.</li>
                 <li><strong>Visual overrides:</strong> Material and reflective tweaks are documented under <a href="./fpe-physics-and-colliders.html">Physics and Colliders</a> and <a href="./fpe-object-behaviors.html">Objects and Characters</a> for easy lookup.</li>
             </ul>
 

--- a/src/website/docs/fpe-object-behaviors.html
+++ b/src/website/docs/fpe-object-behaviors.html
@@ -36,8 +36,8 @@
         <div class="section-body">
             <h2>Players vs. Characters</h2>
             <ul>
-                <li><strong>PlayerControls:</strong> wraps <code>CharacterControls</code> with camera setup, device proxies, and hold zones. First-person enables a tight offset camera; third-person aligns and follows.</li>
-                <li><strong>CharacterControls:</strong> supports movement, jumping, optional sidekicks, and conversation metadata. Use for NPCs that need physics and animations but not player input.</li>
+                <li><strong>Player Controls</strong> (<code>PlayerControls</code>): wraps <strong>Character Controls</strong> with camera setup, device proxies, and hold zones. First-person enables a tight offset camera; third-person aligns and follows.</li>
+                <li><strong>Character Controls</strong> (<code>CharacterControls</code>): supports movement, jumping, optional sidekicks, and conversation metadata. Use for NPCs that need physics and animations but not player input.</li>
                 <li><strong>Flip disable:</strong> Player configurations that choose first- or third-person will disable mesh flipping so strafing does not rotate the rig unexpectedly.</li>
             </ul>
             <h2>Player camera</h2>
@@ -53,7 +53,7 @@
             </ul>
             <h2>Group and script hooks</h2>
             <ul>
-                <li>Use Blender groups or custom ScriptPath metadata to bind Godot scripts to imported nodes without manual scene edits.</li>
+                <li>Use Blender groups or custom <strong>Script Path</strong> metadata (<code>ScriptPath</code>) to bind Godot scripts to imported nodes without manual scene edits.</li>
                 <li>Groups are respected at import time, enabling command filters and deletion-by-group commands.</li>
             </ul>
         </div>

--- a/src/website/docs/fpe-subscenes-and-levels.html
+++ b/src/website/docs/fpe-subscenes-and-levels.html
@@ -49,7 +49,7 @@
             <h2>One-click whole level transitions</h2>
             <ol>
                 <li>Place a trigger near your doorway or portal (see Triggers guide).</li>
-                <li>Add a <strong>LoadLevel</strong> command and point it at the next GLB path (relative to your project).</li>
+                <li>Add a <strong>Load Level</strong> (<code>LoadLevel</code>) command and point it at the next GLB path (relative to your project).</li>
                 <li>When fired, FPE unloads the current level, clears global registries (speakers, cameras, animations), and loads the new GLB cleanly.</li>
                 <li>Tip: pair with a quick fade or loading screen sub-scene so the player sees a smooth handoff.</li>
             </ol>
@@ -57,7 +57,7 @@
             <h3>Quick fade recipe</h3>
             <ul>
                 <li>Create a simple full-screen plane or color-rect UI Element in Blender (black or dark gray works well) and animate its opacity.</li>
-                <li>Export it as a sub-scene and trigger <strong>LoadSubScene</strong> to show the fade, then run <strong>LoadLevel</strong>. When the new level is ready, animate the fade back down and unload the sub-scene.</li>
+                <li>Export it as a sub-scene and trigger <strong>Load Sub Scene</strong> (<code>LoadSubScene</code>) to show the fade, then run <strong>Load Level</strong> (<code>LoadLevel</code>). When the new level is ready, animate the fade back down and unload the sub-scene.</li>
                 <li>This keeps the player from seeing mid-load pops while staying fully no-code for Creator Users.</li>
             </ul>
 
@@ -72,9 +72,9 @@
 
             <h2>Commands for streaming</h2>
             <ul>
-                <li><strong>LoadSubScene</strong>: Load a sub-scene by name or host node path. Great for stepping inside a house while keeping the street loaded.</li>
-                <li><strong>UnloadSubScene</strong>: Unload a named sub-scene and optionally wait a few seconds to finish fades.</li>
-                <li><strong>UnloadThisSubScene</strong>: From inside a sub-scene, call this to close yourself (handy on an exit trigger inside the streamed area).</li>
+                <li><strong>Load Sub Scene</strong> (<code>LoadSubScene</code>): Load a sub-scene by name or host node path. Great for stepping inside a house while keeping the street loaded.</li>
+                <li><strong>Unload Sub Scene</strong> (<code>UnloadSubScene</code>): Unload a named sub-scene and optionally wait a few seconds to finish fades.</li>
+                <li><strong>Unload This Sub Scene</strong> (<code>UnloadThisSubScene</code>): From inside a sub-scene, call this to close yourself (handy on an exit trigger inside the streamed area).</li>
             </ul>
 
             <div class="callouts">
@@ -93,21 +93,21 @@
             <h2>Pause control during transitions</h2>
             <ul>
                 <li>Sub scene hosts can pause parent activities while the child is loaded. That keeps NPCs or physics from running while the player is away.</li>
-                <li>Use <strong>DeactivatePlayerControls</strong> plus a camera cut to hide loading, then <strong>ReactivatePlayerControls</strong> when ready.</li>
+                <li>Use <strong>Deactivate Player Controls</strong> (<code>DeactivatePlayerControls</code>) plus a camera cut to hide loading, then <strong>Reactivate Player Controls</strong> (<code>ReactivatePlayerControls</code>) when ready.</li>
             </ul>
 
             <h2>Design templates</h2>
             <ul>
-                <li><strong>Interior door:</strong> Trigger on the doorframe → <code>LoadSubScene</code> for the interior → on the interior exit trigger, run <code>UnloadThisSubScene</code> and, if you disabled it, <code>ReactivatePlayerCamera</code>.</li>
-                <li><strong>Hub world with portals:</strong> Each portal trigger runs <code>LoadLevel</code> to another GLB. Keep a shared UI scene loaded to show tips during transitions.</li>
-                <li><strong>Elevator cutscene:</strong> Trigger → <code>DeactivatePlayerControls</code> → play lift animation with frame events → <code>LoadLevel</code> to the next floor.</li>
+                <li><strong>Interior door:</strong> Trigger on the doorframe → <code>Load Sub Scene</code> (<code>LoadSubScene</code>) for the interior → on the interior exit trigger, run <code>Unload This Sub Scene</code> (<code>UnloadThisSubScene</code>) and, if you disabled it, <code>Reactivate Player Camera</code> (<code>ReactivatePlayerCamera</code>).</li>
+                <li><strong>Hub world with portals:</strong> Each portal trigger runs <code>Load Level</code> (<code>LoadLevel</code>) to another GLB. Keep a shared UI scene loaded to show tips during transitions.</li>
+                <li><strong>Elevator cutscene:</strong> Trigger → <code>Deactivate Player Controls</code> (<code>DeactivatePlayerControls</code>) → play lift animation with frame events → <code>Load Level</code> (<code>LoadLevel</code>) to the next floor.</li>
             </ul>
 
             <h2>Checks if something feels broken</h2>
             <ul>
                 <li>Verify paths: GLB paths are relative to the project. Typos silently skip loading.</li>
                 <li>Apply transforms before export so the sub-scene spawns at the expected size and position.</li>
-                <li>If old sounds or cameras keep playing after a load, make sure you are using <strong>LoadLevel</strong> (not a custom script) so the runtime clears registries.</li>
+                <li>If old sounds or cameras keep playing after a load, make sure you are using <strong>Load Level</strong> (<code>LoadLevel</code>)—not a custom script—so the runtime clears registries.</li>
             </ul>
         </div>
     </section>

--- a/src/website/docs/fpe-triggers-commands.html
+++ b/src/website/docs/fpe-triggers-commands.html
@@ -52,16 +52,16 @@
 
             <h2>Popular commands you can chain</h2>
             <ul>
-                <li><strong>LoadLevel</strong>: Switch to another GLB/scene. Perfect for doors and portals.</li>
-                <li><strong>LoadSubScene / UnloadSubScene / UnloadThisSubScene</strong>: Stream a room or interior in/out while staying in the same level.</li>
-                <li><strong>SpeakerTrigger / SpeakerTriggerSelf</strong>: Play a specific Speaker by name, or the Speaker on the trigger node.</li>
-                <li><strong>Animations / StopAnimations</strong>: Play or stop comma-separated animation names (works with frame events too).</li>
-                <li><strong>ActivateCamera / ReactivatePlayerCamera</strong>: Cut to a cinematic camera, then give control back.</li>
-                <li><strong>Deactivate/ReactivatePlayerControls</strong>: Temporarily pause movement during menus or cutscenes.</li>
-                <li><strong>StartConversation</strong>: Begin a dialogue using the conversation data on your Speaker/NPC.</li>
-                <li><strong>Pause/ResumeSpecificActivities</strong>: Freeze physics or movement types by ID while something else runs.</li>
-                <li><strong>DispatchEvent</strong>: Emit a custom event name that other triggers or scripts can listen to.</li>
-                <li><strong>DeleteByGroup</strong>: Remove every node in a group (useful for clearing props after a puzzle).</li>
+                <li><strong>Load Level</strong> (<code>LoadLevel</code>): Switch to another GLB/scene. Perfect for doors and portals.</li>
+                <li><strong>Load / Unload Sub Scene</strong> (<code>LoadSubScene</code> / <code>UnloadSubScene</code> / <code>UnloadThisSubScene</code>): Stream a room or interior in/out while staying in the same level.</li>
+                <li><strong>Speaker Trigger</strong> (<code>SpeakerTrigger</code> / <code>SpeakerTriggerSelf</code>): Play a specific Speaker by name, or the Speaker on the trigger node.</li>
+                <li><strong>Animations / Stop Animations</strong> (<code>Animations</code> / <code>StopAnimations</code>): Play or stop comma-separated animation names (works with frame events too).</li>
+                <li><strong>Activate Camera / Reactivate Player Camera</strong> (<code>ActivateCamera</code> / <code>ReactivatePlayerCamera</code>): Cut to a cinematic camera, then give control back.</li>
+                <li><strong>Deactivate / Reactivate Player Controls</strong> (<code>DeactivatePlayerControls</code> / <code>ReactivatePlayerControls</code>): Temporarily pause movement during menus or cutscenes.</li>
+                <li><strong>Start Conversation</strong> (<code>StartConversation</code>): Begin a dialogue using the conversation data on your Speaker/NPC.</li>
+                <li><strong>Pause / Resume Specific Activities</strong> (<code>PauseSpecificActivities</code> / <code>ResumeSpecificActivities</code>): Freeze physics or movement types by ID while something else runs.</li>
+                <li><strong>Dispatch Event</strong> (<code>DispatchEvent</code>): Emit a custom event name that other triggers or scripts can listen to.</li>
+                <li><strong>Delete By Group</strong> (<code>DeleteByGroup</code>): Remove every node in a group (useful for clearing props after a puzzle).</li>
             </ul>
 
             <h2>Inventory-aware triggers</h2>
@@ -72,9 +72,9 @@
 
             <h2>Design patterns to copy</h2>
             <ul>
-                <li><strong>Pressure plate puzzle:</strong> Trigger on ENTER → play a click sound (<code>SpeakerTrigger</code>), open the door (<code>Animations</code>), and disable itself (<code>DeleteByGroup</code> on a helper group).</li>
-                <li><strong>Cutscene starter:</strong> Trigger on ENTER → <code>DeactivatePlayerControls</code> → <code>ActivateCamera</code> → run an <code>Animations</code> clip with frame events → <code>ReactivatePlayerCamera</code> → <code>ReactivatePlayerControls</code>.</li>
-                <li><strong>Scene exit:</strong> Trigger on ENTER → <code>LoadLevel</code> with the next GLB path. Pair with a fade or loading screen sub-scene for polish.</li>
+                <li><strong>Pressure plate puzzle:</strong> Trigger on ENTER → play a click sound (<code>Speaker Trigger</code>) → open the door (<code>Animations</code>) → disable itself (<code>Delete By Group</code> on a helper group).</li>
+                <li><strong>Cutscene starter:</strong> Trigger on ENTER → <code>Deactivate Player Controls</code> → <code>Activate Camera</code> → run an <code>Animations</code> clip with frame events → <code>Reactivate Player Camera</code> → <code>Reactivate Player Controls</code>.</li>
+                <li><strong>Scene exit:</strong> Trigger on ENTER → <code>Load Level</code> with the next GLB path. Pair with a fade or loading screen sub-scene for polish.</li>
             </ul>
 
             <h2>Troubleshooting triggers</h2>

--- a/src/website/docs/fpe-troubleshooting.html
+++ b/src/website/docs/fpe-troubleshooting.html
@@ -65,7 +65,7 @@
             <ul>
                 <li><strong>Scene reload glitches:</strong> register unload procedures for custom systems, and avoid storing references to nodes that will be freed during <code>global_unload_level</code>.</li>
                 <li><strong>Paused controls:</strong> if movement is frozen, check the global deactivate flags (player controls, character movement, triggers, UI). Commands may have toggled these during cutscenes.</li>
-                <li><strong>Missing transition fades:</strong> load the fade sub-scene just before running <code>LoadLevel</code>, then unload it in the new scene once the player regains control.</li>
+                <li><strong>Missing transition fades:</strong> load the fade sub-scene just before running <strong>Load Level</strong> (<code>LoadLevel</code>), then unload it in the new scene once the player regains control.</li>
             </ul>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- Updated object behavior docs to use creator-facing labels like Player Controls, Character Controls, and Script Path instead of internal names.
- Refreshed trigger, animation, and sub-scene guides to present commands with friendly labels alongside their code identifiers for clearer recipes.
- Clarified troubleshooting notes with readable command names (e.g., Load Level) to match the Blender panel terminology.

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923d008de088323a6ce04cc8fa56263)