### PR TITLE
Make documentation hub hero cards clickable

### DIFF
--- a/src/website/docs/folded-paper-engine-guide.html
+++ b/src/website/docs/folded-paper-engine-guide.html
@@ -89,24 +89,24 @@
                 </div>
             </div>
             <div class="doc-grid">
-                <div class="doc-card">
+                <a class="doc-card" href="./fpe-installation.html">
                     <div class="doc-card-title">Quick start</div>
                     <div class="doc-card-body">
                         Install the Blender add-on, enable the Godot plug-in, and follow the pipeline and troubleshooting pages to export clean GLBs every time.
                     </div>
-                </div>
-                <div class="doc-card">
+                </a>
+                <a class="doc-card" href="./fpe-object-behaviors.html">
                     <div class="doc-card-title">Gameplay systems</div>
                     <div class="doc-card-body">
                         Jump to objects, physics, triggers, inventory, conversations, UI, input, cameras, and sub-scenes to wire up interactions without code.
                     </div>
-                </div>
-                <div class="doc-card">
+                </a>
+                <a class="doc-card" href="./fpe-doc-coverage.html">
                     <div class="doc-card-title">Reference & coverage</div>
                     <div class="doc-card-body">
                         Use the coverage map to see where every feature is documented and close gaps fast when new behaviors ship.
                     </div>
-                </div>
+                </a>
             </div>
             <div class="doc-grid">
                 <a class="doc-card" href="./fpe-installation.html">


### PR DESCRIPTION
## Summary
- make the top hero cards in the documentation hub clickable, linking to installation, gameplay systems, and coverage pages

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923d00aaa048323b59ad112d3ef183d)