### PR TITLE
Use friendlier quick start label

### DIFF
--- a/src/website/docs/folded-paper-engine-guide.html
+++ b/src/website/docs/folded-paper-engine-guide.html
@@ -66,7 +66,7 @@
             </p>
             <div class="callouts">
                 <div class="callout">
-                    <div class="callout-title">Quick start anchors</div>
+                    <div class="callout-title">Quick start links</div>
                     <div class="callout-body">
                         <ul>
                             <li><a href="./fpe-installation.html">Install both add-ons</a> then confirm the engine node loads your GLB.</li>


### PR DESCRIPTION
## Summary
- Rename the documentation hub callout title from “Quick start anchors” to the more user-friendly “Quick start links.”

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923d00983048323b47aba0973a695d7)