### PR TITLE
fix: (godot-addon-frame-ticker) Fix the frame number that stop resets…

### DIFF
--- a/src/Game/addons/folded_paper_engine/Engine/Features/Object/SpriteAnimate/FrameTicker.gd
+++ b/src/Game/addons/folded_paper_engine/Engine/Features/Object/SpriteAnimate/FrameTicker.gd
@@ -61,4 +61,4 @@ func pause() -> void:
 
 func stop() -> void:
 	_PLAYING = false
-	_current_frame = 0.0
+	_current_frame = 1.0


### PR DESCRIPTION
… to.