### PR TITLE
feat: improve website search signals

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,9 @@ export default defineConfig({
   integrations: [
     react(),
     sitemap({
+      filter(page) {
+        return !page.includes("/godot-api-docs/");
+      },
       serialize(item) {
         if (item.url === "https://foldedpaperengine.com/") {
           return {...item, url: "https://foldedpaperengine.com"};

--- a/planning/fix-fpe-google-search-issues.md
+++ b/planning/fix-fpe-google-search-issues.md
@@ -1,0 +1,16 @@
+# Fix FPE Google Search Issues
+
+## Goal
+
+Improve Folded Paper Engine site SEO signals based on the Google search issues screenshot in `~/Downloads/google-search-issues.png`.
+
+## Checklist
+
+- [x] Create a feature branch with `gittoit`.
+- [x] Inspect the current website build and generated docs structure.
+- [x] Improve page titles and metadata for Blender/Godot documentation pages.
+- [x] Add clearer contextual internal links from high-value pages to docs.
+- [x] Prevent raw/generated API dump pages from competing in search when appropriate.
+- [x] Build or validate the site locally.
+- [x] Update this plan with completed work.
+- [x] Commit, push, and open a pull request with `gh`.

--- a/public/assets/css/index.css
+++ b/public/assets/css/index.css
@@ -1054,6 +1054,21 @@ body {
     margin: 0;
 }
 
+.feature-grid p + p {
+    margin-top: 0.85rem;
+}
+
+.feature-grid a {
+    color: var(--teal);
+    font-weight: 800;
+    text-decoration-color: rgba(76, 115, 121, 0.35);
+    text-underline-offset: 0.22em;
+}
+
+.feature-grid a:hover {
+    color: var(--coral);
+}
+
 .mechanics-section {
     background: #fffaf0;
 }

--- a/src/website/layouts/SiteLayout.astro
+++ b/src/website/layouts/SiteLayout.astro
@@ -12,6 +12,7 @@ const {
   description,
   image,
   pageHeading,
+  robots = "index, follow, max-image-preview:large",
   structuredData = [],
 } = Astro.props;
 
@@ -93,7 +94,7 @@ const supportUrls = {
             content="width=device-width, initial-scale=1, maximum-scale=1"
     />
     <meta name="description" content={pageDescription}/>
-    <meta name="robots" content="index, follow, max-image-preview:large"/>
+    <meta name="robots" content={robots}/>
     <meta name="author" content="Papercraft Games"/>
     <meta property="og:site_name" content={siteName}/>
     <meta property="og:type" content="website"/>

--- a/src/website/pages/godot-api-docs/[slug].astro
+++ b/src/website/pages/godot-api-docs/[slug].astro
@@ -21,6 +21,7 @@ const pageDescription =
     title={page.title}
     description={pageDescription}
     image="/assets/images/godot-feature-splash.png"
+    robots="noindex, follow, max-image-preview:large"
 >
     <article class="api-doc-article">
         <div class="api-doc-body" set:html={page.bodyHtml}/>

--- a/src/website/pages/index.astro
+++ b/src/website/pages/index.astro
@@ -99,17 +99,17 @@ const supportUrls = {
         <div class="doc-grid">
             <a class="doc-card" href="/blender-panel-docs.html">
                 <img src="/assets/images/blender-logo-icon.png" alt="">
-                <span>Blender Panels</span>
+                <span>Folded Paper Engine Blender Panel Docs</span>
                 <small>Author gameplay metadata where your level already lives.</small>
             </a>
             <a class="doc-card" href="/godot-feature-docs.html">
                 <img src="/assets/images/godot-logo-icon.png" alt="">
-                <span>Godot Features</span>
+                <span>Folded Paper Engine Godot Feature Docs</span>
                 <small>See how imported scene data becomes runtime behavior.</small>
             </a>
             <a class="doc-card" href="/godot-api-docs.html">
                 <img src="/assets/images/guide-icon.png" alt="">
-                <span>Godot API</span>
+                <span>Folded Paper Engine Godot API Index</span>
                 <small>Reference the scripts and extension points behind FPE.</small>
             </a>
             <a class="doc-card" href="/youtube-tutorials.html">
@@ -166,8 +166,10 @@ const supportUrls = {
                 scripts.
             </p>
             <nav class="mechanics-links" aria-label="Learn more about Folded Paper Engine mechanics">
-                <a href="/blender-panel-docs.html">Blender game logic panels</a>
-                <a href="/godot-feature-docs.html">Godot gameplay features</a>
+                <a href="/blender-panel-docs.html">Folded Paper Engine Blender game logic panels</a>
+                <a href="/godot-feature-docs.html">Folded Paper Engine Godot gameplay features</a>
+                <a href="/docs/fpe-triggers-commands.html">Trigger and command guide</a>
+                <a href="/docs/fpe-characters-players-and-cameras.html">Player and camera guide</a>
                 <a href="/youtube-tutorials.html">Blender to Godot tutorials</a>
                 <a href="/demo.html">Playable demo</a>
             </nav>
@@ -185,26 +187,32 @@ const supportUrls = {
             <article>
                 <h3>Characters & Players</h3>
                 <p>Configure rigs, NPCs, camera behavior, and player-facing metadata directly on scene objects.</p>
+                <p><a href="/docs/fpe-characters-players-and-cameras.html">Read the Folded Paper Engine character guide.</a></p>
             </article>
             <article>
                 <h3>Triggers & Events</h3>
                 <p>Define area triggers, command catalogs, scene events, and animation frame events in the authoring file.</p>
+                <p><a href="/docs/fpe-triggers-commands.html">Read the Folded Paper Engine trigger guide.</a></p>
             </article>
             <article>
                 <h3>Physics & Interaction</h3>
                 <p>Mark holdable items, inventory objects, rigid bodies, and collider behavior before export.</p>
+                <p><a href="/docs/fpe-physics-and-colliders.html">Read the Folded Paper Engine physics guide.</a></p>
             </article>
             <article>
                 <h3>Scene Management</h3>
                 <p>Carry sky color, sub-scenes, loading behavior, UI elements, and scene metadata into Godot.</p>
+                <p><a href="/docs/fpe-scene-settings.html">Read the Folded Paper Engine scene settings guide.</a></p>
             </article>
             <article>
                 <h3>Audio</h3>
                 <p>Set up music imports, looping, autoplay, background tracks, and speakers as part of level authoring.</p>
+                <p><a href="/docs/fpe-audio.html">Read the Folded Paper Engine audio guide.</a></p>
             </article>
             <article>
                 <h3>Escape Hatches</h3>
                 <p>Override generated behavior, add custom scripts, or extend FPE's modular runtime when a scene needs more.</p>
+                <p><a href="/godot-api-docs.html">Browse the Folded Paper Engine Godot API index.</a></p>
             </article>
         </div>
     </section>

--- a/src/website/seo.ts
+++ b/src/website/seo.ts
@@ -141,8 +141,22 @@ export function getPageSeo(pathname: string): PageSeo | undefined {
 }
 
 export function getPageTitle(pathname: string, title: string): string {
-  if (normalizePathname(pathname) === "/") {
+  const normalizedPathname = normalizePathname(pathname);
+
+  if (normalizedPathname === "/") {
     return `${title} | ${SITE_NAME}`;
+  }
+
+  if (
+    normalizedPathname === "/blender-panel-docs" ||
+    normalizedPathname === "/godot-feature-docs" ||
+    normalizedPathname.startsWith("/docs/")
+  ) {
+    return `${title} | ${SITE_NAME} Documentation`;
+  }
+
+  if (normalizedPathname.startsWith("/godot-api-docs")) {
+    return `${title} | ${SITE_NAME} Godot API Reference`;
   }
 
   return `${title} | ${SITE_NAME}`;


### PR DESCRIPTION
## Summary
- add branded documentation/API title suffixes for FPE docs pages
- noindex generated Godot API class pages while keeping the API index crawlable
- remove generated API class pages from the sitemap
- strengthen homepage contextual links into the Blender, Godot, and guide docs

## Validation
- yarn build:web
- local preview smoke checks at http://127.0.0.1:4321/ for robots tags, titles, sitemap output, and homepage links